### PR TITLE
Fix CSV export options to use the new Printer

### DIFF
--- a/docs/frame/writing.md
+++ b/docs/frame/writing.md
@@ -63,20 +63,23 @@ file with various customizations applied via the `CsvSinkOptions` object. The cu
 <?prettify?>
 ```java
 frame.write().csv(options -> {
-    options.setFile("/Users/witdxav/morpheus/tests/DataFrame-1.csv");
+    options.setFile("DataFrame-1.csv");
     options.setSeparator(",");
     options.setIncludeRowHeader(true);
     options.setIncludeColumnHeader(true);
     options.setNullText("null");
     options.setTitle("Date");
-    options.setRowKeyPrinter(LocalDate::toString);
+
+    DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd/MMM/yyyy");
+    options.setRowKeyPrinter(Printer.ofLocalDate(dateFormat));
+
     options.setFormats(formats -> {
         DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm");
         DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm");
         formats.setDecimalFormat(Double.class, "0.00##;-0.00##", 1);
-        formats.<Month>setPrinter("Column-2", v -> v.name().toLowerCase());
-        formats.<LocalTime>setPrinter("Column-1", timeFormat::format);
-        formats.<LocalDateTime>setPrinter("Column-5", dateTimeFormat::format);
+        formats.setPrinter("Column-2", Printer.ofLocalTime(timeFormat));
+        formats.<Month>setPrinter("Column-3", Printer.forObject(m -> m.name().toLowerCase()));
+        formats.setPrinter("Column-6", Printer.ofLocalDateTime(dateTimeFormat));
     });
 });
 ```
@@ -166,14 +169,14 @@ to the simple name of the class.
 <?prettify?>
 ```java
 frame.write().json(options -> {
-    options.setFile("/Users/witdxav/morpheus/tests/DataFrame-1.json");
+    options.setFile("DataFrame-1.json");
     options.setEncoding("UTF-8");
     options.setFormats(formats -> {
         DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm");
         DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm");
-        formats.<Month>setPrinter("Column-2", v -> v.name().toLowerCase());
-        formats.<LocalTime>setPrinter("Column-1", timeFormat::format);
-        formats.<LocalDateTime>setPrinter("Column-5", dateTimeFormat::format);
+        formats.setPrinter("Column-2", Printer.ofLocalTime(timeFormat));
+        formats.<Month>setPrinter("Column-3", Printer.forObject(m -> m.name().toLowerCase()));
+        formats.setPrinter("Column-6", Printer.ofLocalDateTime(dateTimeFormat));
     });
 });
 ```


### PR DESCRIPTION
The CSV export example wasn't compiling.
The Printer required by the `CsvSinkOptions.setRowKeyPrinter()` isn't a functional interface anymore.
This way, lambda expressions or method references are not valid.
The previous instruction `options.setRowKeyPrinter(LocalDate::toString)` had to be changed to:
```java
DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd/MMM/yyyy");
options.setRowKeyPrinter(Printer.ofLocalDate(dateFormat));
```

The last 3 lines inside the lambda given to the `options.setFormats()` method had to be changed to:
```java
formats.setPrinter("Column-2", Printer.ofLocalTime(timeFormat));
formats.<Month>setPrinter("Column-3", Printer.forObject(m -> m.name().toLowerCase()));
formats.setPrinter("Column-6", Printer.ofLocalDateTime(dateTimeFormat));
```
The previous code, besides not being adapted to the new `CsvSinkOptions.setPrinter()` method signature, was defining the format for the wrong columns (causing runtime type cast exceptions).

The same issues were fixed for the JSON example.
The output file names were defined with an absolute path. It was changed to a relative one.